### PR TITLE
Fix Pył analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# don't commit new files from Executables and Output dirs
+Executables/
+Output/
+
+# ignore cloned repository
+OpenWatcom/open-watcom-v2/
+
+__pycache__
+
+.dccache

--- a/Wcdatool/modules/main_wdump.py
+++ b/Wcdatool/modules/main_wdump.py
@@ -301,9 +301,13 @@ def wdump_decode_data(section):
 		for line in section["data"]:
 			line2 = str.join(" ", line.split())
 
-			match = re.match("^([0-9]+) ([0-9]+) src off = ([0-9a-fA-F ]+) object # = ([0-9]+) target off = ([0-9a-fA-F ]+)$", line2)
+			match = re.match("^([0-9]+) ([0-9]+) src off = ([0-9a-fA-F ]+) object # = ([0-9]+) target off = ?([0-9a-fA-F ]+)?$", line2)
 			if (match):
-				decoded_data.append(OrderedDict([("source type", int(match.group(1))), ("target flags", int(match.group(2))), ("source offset", int(match.group(3), 16)), ("object", int(match.group(4))), ("target offset", int(match.group(5), 16))]))
+				# target off can be empty
+				decoded_data_offset = 0
+				if match.group(5) is not None:
+					decoded_data_offset = int(match.group(5), 16)
+				decoded_data.append(OrderedDict([("source type", int(match.group(1))), ("target flags", int(match.group(2))), ("source offset", int(match.group(3), 16)), ("object", int(match.group(4))), ("target offset", decoded_data_offset)]))
 				continue
 
 			if (line2 == "Source Target" or line2 == "type flags" or line2 == "==== ===="):


### PR DESCRIPTION
Polish DOS game Pył ([PCGamingWiki](https://www.pcgamingwiki.com/wiki/Py%C5%82),  [exe](https://drive.google.com/file/d/1RXPIRgyAhtKIpV15OPuShGo3-vDnKyyD/view?usp=sharing)) from 1998 currently have issues during the scan:

* the game uses tbytes (and  probably `fwords` if I'm reading asm correctly) , this PR should fix parsing errors
```
[1680991175] [ERROR   ] Failed to interpret access size: ['TBYTE']
[1680991175] [ERROR   ] Failed to interpret access size: ['TBYTE']
[1680991175] [ERROR   ] Failed to interpret access size: ['TBYTE']
[1680991175] [ERROR   ] Failed to interpret access size: ['TBYTE']
[1680991175] [ERROR   ] Failed to interpret access size: ['TBYTE']
[1680991175] [ERROR   ] Failed to interpret access size: ['TBYTE']
[1680991175] [ERROR   ] Failed to interpret access size: ['TBYTE']
[1680991175] [ERROR   ] Failed to interpret access size: ['TBYTE']
[1680991175] [ERROR   ] Failed to interpret access size: ['TBYTE']
[1680991175] [ERROR   ] Failed to interpret access size: ['TBYTES']
```

* wdump `Fixup Record Table` can return empty `target off`
    * example `   02    00   src off = 039D   object #    = 05   target off       = `
    * I'm not sure if wcdatool should default target offset to 0
    * I've used open-watcom `Last-CI-build` (commit `60f78534a5f154711579d567642b3cb7cead2185`)
